### PR TITLE
Add jobs for testing and spell checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   CLICOLOR: 1
@@ -20,13 +26,6 @@ jobs:
           xcode-select-version: 16.1
       - name: Test
         run: set -o pipefail && swift test | xcbeautify --renderer github-actions
-  test-ubuntu:
-    name: Test on Ubuntu 24.04
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test
-        run: set -o pipefail && swift test
   spelling:
     name: Spell Check with Typos
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,7 @@ name: CI
 permissions:
   contents: read
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 env:
   CLICOLOR: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  test-macos:
+    name: Test on macOS 14
+    runs-on: macOS-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Xcode Select Version
+        uses: mobiledevops/xcode-select-version-action@v1
+        with:
+          xcode-select-version: 16.1
+      - name: Test
+        run: set -o pipefail && swift test | xcbeautify --renderer github-actions
+  test-ubuntu:
+    name: Test on Ubuntu 24.04
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: set -o pipefail && swift test
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Spell Check Repo
+        uses: crate-ci/typos@v1.31.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: CI
 
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CLICOLOR: 1
+
 jobs:
   test-macos:
     name: Test on macOS 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,5 @@
 name: CI
 
-permissions:
-  contents: read
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
-env:
-  CLICOLOR: 1
-
 jobs:
   test-macos:
     name: Test on macOS 14


### PR DESCRIPTION
I added two jobs for testing on macOS ~~and Linux~~ and one job for spell checking with [Typos](https://github.com/crate-ci/typos).

The job fails on Linux. See the discussion below.

See also: https://github.com/crate-ci/typos/blob/master/docs/github-action.md
Related to: https://github.com/md-babel/swift-markdown-babel/issues/1