### PR TITLE
Assemble (Linux) release binary using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+/release/*
+!/release/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# ================================
+# Build image
+# ================================
+FROM swift:6.1.0-noble AS build
+
+# Install OS updates
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get install -y libjemalloc-dev
+
+# Set up a build area
+WORKDIR /build
+
+# First just resolve dependencies.
+# This creates a cached layer that can be reused
+# as long as your Package.swift/Package.resolved
+# files do not change.
+COPY ./Package.* ./
+RUN swift package resolve \
+    $([ -f ./Package.resolved ] && echo "--force-resolved-versions" || true)
+
+# Copy entire repo into container
+COPY . .
+
+# Build the application
+RUN swift build -c release \
+    --product md-babel \
+    --static-swift-stdlib
+
+WORKDIR /staging
+
+# Copy main executable to staging area
+RUN cp "$(swift build --package-path /build -c release --show-bin-path)/md-babel" ./
+
+# ================================
+# Export build product
+# ================================
+# Usage:
+#  $ docker build --target export -o . .
+FROM scratch AS export
+COPY --from=build /staging/md-babel /

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ release/md-babel_linux-amd64.tar.bz2 release/md-babel_linux-arm64.tar.bz2 &:
 	tar --create --bzip2 --file release/md-babel_linux-amd64.tar.bz2 --directory release/linux_amd64 md-babel
 	tar --create --bzip2 --file release/md-babel_linux-arm64.tar.bz2 --directory release/linux_arm64 md-babel
 
+.PHONY: clean
+clean:
+	rm -rf release/*.tar.bz2 release/linux_*
 
 .PHONY: release
 release: release/md-babel_linux-arm64.tar.bz2 release/md-babel_linux-amd64.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 release/md-babel_linux-amd64.tar.bz2 release/md-babel_linux-arm64.tar.bz2 &:
 	docker buildx build --quiet --platform linux/amd64,linux/arm64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
-	tar -cjf release/md-babel_linux-amd64.tar.bz2 -C release/linux_amd64 md-babel
-	tar -cjf release/md-babel_linux-arm64.tar.bz2 -C release/linux_arm64 md-babel
+	tar --create --bzip2 --file release/md-babel_linux-amd64.tar.bz2 --directory release/linux_amd64 md-babel
+	tar --create --bzip2 --file release/md-babel_linux-arm64.tar.bz2 --directory release/linux_arm64 md-babel
 
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+release/md-babel_linux-amd64.tar.bz2:
+	docker buildx build --quiet --platform linux/amd64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
+	cd release && tar -cjf md-babel_linux-amd64.tar.bz2 -C linux_amd64 md-babel
+
+release/md-babel_linux-arm64.tar.bz2:
+	docker buildx build --quiet --platform linux/arm64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
+	cd release && tar -cjf md-babel_linux-arm64.tar.bz2 -C linux_arm64 md-babel
+
+.PHONY: build
+build:
+	docker buildx build --quiet --platform linux/amd64,linux/arm64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
+
+.PHONY: release
+release: release/md-babel_linux-arm64.tar.bz2 release/md-babel_linux-amd64.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,8 @@
-release/md-babel_linux-amd64.tar.bz2:
-	docker buildx build --quiet --platform linux/amd64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
-	cd release && tar -cjf md-babel_linux-amd64.tar.bz2 -C linux_amd64 md-babel
-
-release/md-babel_linux-arm64.tar.bz2:
-	docker buildx build --quiet --platform linux/arm64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
-	cd release && tar -cjf md-babel_linux-arm64.tar.bz2 -C linux_arm64 md-babel
-
-.PHONY: build
-build:
+release/md-babel_linux-amd64.tar.bz2 release/md-babel_linux-arm64.tar.bz2 &:
 	docker buildx build --quiet --platform linux/amd64,linux/arm64 --tag md-babel/swift-markdown-babel --target export --output=./release/ .
+	tar -cjf release/md-babel_linux-amd64.tar.bz2 -C release/linux_amd64 md-babel
+	tar -cjf release/md-babel_linux-arm64.tar.bz2 -C release/linux_arm64 md-babel
+
 
 .PHONY: release
 release: release/md-babel_linux-arm64.tar.bz2 release/md-babel_linux-amd64.tar.bz2

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+pushd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null
+
+BUILD_ARGS=(
+	--product md-babel
+	--configuration release
+)
+
+if [[ -z "$TARGETPLATFORM" ]]; then
+	ARCH="$(uname -m)"
+else
+	BUILD_ARGS+=(--cache-path /workspace/.spm-cache)
+	if [[ "$TARGETPLATFORM" = "linux/amd64" ]]; then
+		ARCH="x86_64"
+	elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then
+		ARCH="aarch64"
+	else
+		echo "Unsupported target platform: $TARGETPLATFORM"
+		exit 1
+	fi
+fi
+BUILD_ARGS+=(--swift-sdk "${ARCH}-swift-linux-musl")
+
+swift build "${BUILD_ARGS[@]}"

--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# echo "Update '$(basename "${BASH_SOURCE[0]}")' to use your own '--tag' or use the '.github/workflows/docker-push.yaml' GitHub workflow"
+# exit 1
+
+set -eo pipefail
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
+
+# Tagging a build:
+#   https://docs.docker.com/get-started/docker-concepts/building-images/build-tag-and-publish-an-image/
+# Cross-platform building:
+#   https://docs.docker.com/build/building/multi-platform/#create-a-custom-builder
+docker buildx build \
+	   --platform linux/amd64,linux/arm64 \
+	   --tag md-babel/swift-markdown-babel \
+	   --push \
+	   .


### PR DESCRIPTION
Based on https://github.com/Cyberbeni/MultiArchSwiftDockerfileExample

    $ make release

Works on my machine™ :)

The `scripts/docker-release.sh` is currently not usable, but prepared.