### PR TITLE
Configure image filename pattern and output directory

### DIFF
--- a/Sources/MarkdownBabel/Execute/Either.swift
+++ b/Sources/MarkdownBabel/Execute/Either.swift
@@ -1,12 +1,40 @@
-enum Either<Left, Right> {
+public enum Either<Left, Right> {
 	case left(Left)
 	case right(Right)
+}
+
+extension Either: Codable where Left: Codable, Right: Codable {
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+
+		if let leftValue = try? container.decode(Left.self) {
+			self = .left(leftValue)
+		} else if let rightValue = try? container.decode(Right.self) {
+			self = .right(rightValue)
+		} else {
+			throw DecodingError.dataCorruptedError(
+				in: container,
+				debugDescription: "Cannot decode either \(Left.self) or \(Right.self)"
+			)
+		}
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
+
+		switch self {
+		case .left(let value):
+			try container.encode(value)
+		case .right(let value):
+			try container.encode(value)
+		}
+	}
 }
 
 extension Either: Sendable where Left: Sendable, Right: Sendable {}
 
 extension Either: Equatable where Left: Equatable, Right: Equatable {
-	static func == (lhs: Self, rhs: Self) -> Bool {
+	public static func == (lhs: Self, rhs: Self) -> Bool {
 		return switch (lhs, rhs) {
 		case (.left(let lValue), .left(let rValue)): lValue == rValue
 		case (.right(let lValue), .right(let rValue)): lValue == rValue

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
@@ -1,4 +1,5 @@
 import struct Foundation.Data
+import struct Foundation.URL
 
 public struct CodeToCodeEvaluator: Evaluator, Sendable {
 	public let configuration: EvaluatorConfiguration
@@ -7,7 +8,10 @@ public struct CodeToCodeEvaluator: Evaluator, Sendable {
 		self.configuration = configuration
 	}
 
-	public func run(_ code: String) async throws -> Execute.Response.ExecutionResult.Output {
+	public func run(
+		_ code: String,
+		sourceURL: URL?
+	) async throws -> Execute.Response.ExecutionResult.Output {
 		let (terminationStatus, outputData) = try await runProcess(
 			configuration: self.configuration,
 			standardInput: code

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
@@ -1,0 +1,24 @@
+import struct Foundation.Data
+
+public struct CodeToCodeEvaluator: Evaluator, Sendable {
+	public let configuration: EvaluatorConfiguration
+
+	public init(configuration: EvaluatorConfiguration) {
+		self.configuration = configuration
+	}
+
+	public func run(_ code: String) async throws -> Execute.Response.ExecutionResult.Output {
+		let (terminationStatus, outputData) = try await runProcess(
+			configuration: self.configuration,
+			standardInput: code
+		)
+
+		guard let code = String(data: outputData, encoding: .utf8)
+		else { throw ExecutionFailure.processResultIsNotAString(outputData, terminationStatus) }
+
+		return .init(
+			insert: .codeBlock(language: "", code: code),
+			sideEffect: nil
+		)
+	}
+}

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -18,7 +18,10 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 		self.generateImageFileURL = generateImageFileURL
 	}
 
-	public func run(_ code: String) async throws -> Execute.Response.ExecutionResult.Output {
+	public func run(
+		_ code: String,
+		sourceURL: URL?
+	) async throws -> Execute.Response.ExecutionResult.Output {
 		guard let hashContent = ContentHash(string: code, encoding: .utf8)
 		else { throw ExecutionFailure.hashingContentFailed(code) }
 
@@ -28,7 +31,7 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 		)
 
 		let hash: String = hashContent()
-		let sourceFilename = ""  // TODO: Make filename pattern configurable https://github.com/md-babel/swift-markdown-babel/issues/20
+		let sourceFilename = sourceURL?.deletingPathExtension().lastPathComponent ?? "STDIN"
 		let filename = filename(
 			pattern: imageConfiguration.filenamePattern,
 			sourceFilename: sourceFilename,

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -1,0 +1,32 @@
+import Crypto
+
+import struct Foundation.Data
+import struct Foundation.URL
+
+public struct CodeToImageEvaluator: Evaluator, Sendable {
+	public let configuration: EvaluatorConfiguration
+	public let generateImageFileURL: GenerateImageFileURL
+
+	public init(configuration: EvaluatorConfiguration, generateImageFileURL: GenerateImageFileURL) {
+		self.configuration = configuration
+		self.generateImageFileURL = generateImageFileURL
+	}
+
+	public func run(_ code: String) async throws -> Execute.Response.ExecutionResult.Output {
+		guard let hashContent = ContentHash(string: code, encoding: .utf8)
+		else { throw ExecutionFailure.hashingContentFailed(code) }
+
+		let (_, outputData) = try await runProcess(
+			configuration: self.configuration,
+			standardInput: code
+		)
+
+		let hash: String = hashContent()
+		let filename = "rendered-" + hash  // TODO: Make filename pattern configurable https://github.com/md-babel/swift-markdown-babel/issues/20
+		let imageURL: URL = generateImageFileURL(filename: filename)
+		return .init(
+			insert: .image(path: imageURL.path(), hash: hash),
+			sideEffect: .writeFile(outputData, to: imageURL)
+		)
+	}
+}

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
@@ -1,5 +1,5 @@
 public struct UnrecognizedEvaluationResult: Error, CustomStringConvertible {
-	public let type: String
+	public let type: Either<String, [String: String]>
 
 	public var description: String { "Unrecognized evaluation result type: “\(type)”" }
 }
@@ -7,23 +7,16 @@ public struct UnrecognizedEvaluationResult: Error, CustomStringConvertible {
 /// Type of Markdown node execution result is produced to.
 public enum EvaluationResultMarkup: Hashable, Sendable {
 	case codeBlock
-	case image
-
-	public init(string: String) throws {
-		self =
-			switch string {
-			case "codeBlock": .codeBlock
-			case "image": .image
-			default: throw UnrecognizedEvaluationResult(type: string)
-			}
-	}
+	case image(fileExtension: String, directory: String, filenamePattern: String)
 }
 
 extension EvaluationResultMarkup: CustomStringConvertible {
 	public var description: String {
 		return switch self {
-		case .codeBlock: "code block"
-		case .image: "image"
+		case .codeBlock:
+			"code block"
+		case .image(let fileExtension, let directory, filenamePattern: let pattern):
+			"image (\(directory)/\(pattern).\(fileExtension))"
 		}
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
@@ -7,7 +7,15 @@ public struct UnrecognizedEvaluationResult: Error, CustomStringConvertible {
 /// Type of Markdown node execution result is produced to.
 public enum EvaluationResultMarkup: Hashable, Sendable {
 	case codeBlock
-	case image(fileExtension: String, directory: String, filenamePattern: String)
+	case image(ImageEvaluationConfiguration)
+
+	public static func image(
+		fileExtension: String,
+		directory: String,
+		filenamePattern: String
+	) -> EvaluationResultMarkup {
+		return .image(.init(fileExtension: fileExtension, directory: directory, filenamePattern: filenamePattern))
+	}
 }
 
 extension EvaluationResultMarkup: CustomStringConvertible {
@@ -15,8 +23,8 @@ extension EvaluationResultMarkup: CustomStringConvertible {
 		return switch self {
 		case .codeBlock:
 			"code block"
-		case .image(let fileExtension, let directory, filenamePattern: let pattern):
-			"image (\(directory)/\(pattern).\(fileExtension))"
+		case .image(let config):
+			"image (\(config.directory)/\(config.filenamePattern).\(config.fileExtension))"
 		}
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
@@ -1,7 +1,11 @@
 import struct Foundation.Data
+import struct Foundation.URL
 
 public protocol Evaluator: Sendable {
-	func run(_ input: String) async throws -> Execute.Response.ExecutionResult.Output
+	func run(
+		_ input: String,
+		sourceURL: URL?
+	) async throws -> Execute.Response.ExecutionResult.Output
 }
 
 extension Evaluator {

--- a/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
@@ -1,28 +1,16 @@
-import Crypto
-import Foundation
+import struct Foundation.Data
 
-public struct Evaluator: Sendable {
-	public let configuration: EvaluatorConfiguration
-	public let generateImageFileURL: GenerateImageFileURL
+public protocol Evaluator: Sendable {
+	func run(_ input: String) async throws -> Execute.Response.ExecutionResult.Output
+}
 
-	public init(configuration: EvaluatorConfiguration, generateImageFileURL: GenerateImageFileURL) {
-		self.configuration = configuration
-		self.generateImageFileURL = generateImageFileURL
-	}
-
-	public func result(fromRunning code: String) async -> Execute.Response.ExecutionResult {
-		do {
-			let result = try await run(code: code)
-			return .init(output: result, error: nil)
-		} catch {
-			return .init(output: nil, error: "\(error)")
-		}
-	}
-
-	public func run(code: String) async throws -> Execute.Response.ExecutionResult.Output {
+extension Evaluator {
+	func runProcess(
+		configuration: EvaluatorConfiguration,
+		standardInput: String
+	) async throws -> (RunProcess.TerminationStatus, Data) {
 		let runProcess = configuration.makeRunProcess()
-		let (result, outputData) = try await runProcess(input: code, additionalArguments: [])
-
+		let (result, outputData) = try await runProcess(input: standardInput, additionalArguments: [])
 		let terminationStatus: RunProcess.TerminationStatus =
 			switch result {
 			case .right(let error):
@@ -30,26 +18,6 @@ public struct Evaluator: Sendable {
 			case .left(let status):
 				status
 			}
-
-		switch configuration.resultMarkupType {
-		case .codeBlock:
-			guard let code = String(data: outputData, encoding: .utf8)
-			else { throw ExecutionFailure.processResultIsNotAString(outputData, terminationStatus) }
-			return .init(
-				insert: .codeBlock(language: "", code: code),
-				sideEffect: nil
-			)
-
-		case .image:
-			guard let hashContent = ContentHash(string: code, encoding: .utf8)
-			else { throw ExecutionFailure.hashingContentFailed(code) }
-			let hash: String = hashContent()
-			let filename = "rendered-" + hash  // TODO: Make filename pattern configurable https://github.com/md-babel/swift-markdown-babel/issues/20
-			let imageURL: URL = generateImageFileURL(filename: filename)
-			return .init(
-				insert: .image(path: imageURL.path(), hash: hash),
-				sideEffect: .writeFile(outputData, to: imageURL)
-			)
-		}
+		return (terminationStatus, outputData)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration+json.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration+json.swift
@@ -32,13 +32,10 @@ extension EvaluatorConfiguration {
 		case .left("codeBlock"):
 			resultMarkupType = .codeBlock
 		case .right(let dictionary) where dictionary["type"] == "image":
-			let fileExtension = try dictionary.ensureValue("extension")
-			let directory = try dictionary.ensureValue("directory")
-			let pattern = try dictionary.ensureValue("pattern")
 			resultMarkupType = .image(
-				fileExtension: fileExtension,
-				directory: directory,
-				filenamePattern: pattern
+				fileExtension: try dictionary.ensureValue("extension"),
+				directory: try dictionary.ensureValue("directory"),
+				filenamePattern: try dictionary.ensureValue("filename")
 			)
 		default:
 			throw UnrecognizedEvaluationResult(type: rep.result)
@@ -56,12 +53,12 @@ extension EvaluatorConfiguration {
 		let resultMarkupType: Either<String, [String: String]> =
 			switch self.resultMarkupType {
 			case .codeBlock: .left("codeBlock")
-			case .image(let fileExtension, let directory, filenamePattern: let pattern):
+			case .image(let config):
 				.right([
 					"type": "image",
-					"extension": fileExtension,
-					"directory": directory,
-					"pattern": pattern,
+					"extension": config.fileExtension,
+					"directory": config.directory,
+					"filename": config.filenamePattern,
 				])
 			}
 		let rep = Representation(

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
@@ -4,9 +4,14 @@ import struct Foundation.URL
 ///
 /// These are usually hydrated from configuration files. See ``EvaluatorRegistry``.
 public struct EvaluatorConfiguration: Equatable, Sendable {
+	/// Path to the program to execute during evaluation.
 	public let executableURL: URL
+	/// Command-line arguments to pass to the program during evaluation.
 	public let arguments: [String]
+
+	/// Type of the source block to evaluate.
 	public let executableMarkupType: ExecutableMarkup
+	/// Type of the output to produce.
 	public let resultMarkupType: EvaluationResultMarkup
 
 	public init(

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
@@ -37,3 +37,16 @@ extension EvaluatorConfiguration {
 		)
 	}
 }
+
+extension EvaluatorConfiguration {
+	public func makeEvaluator(
+		generateImageFileURL: GenerateImageFileURL
+	) -> any Evaluator {
+		switch (self.executableMarkupType, self.resultMarkupType) {
+		case (.codeBlock, .codeBlock):
+			return CodeToCodeEvaluator(configuration: self)
+		case (.codeBlock, .image):
+			return CodeToImageEvaluator(configuration: self, generateImageFileURL: generateImageFileURL)
+		}
+	}
+}

--- a/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
@@ -9,15 +9,15 @@ public struct GenerateImageFileURL: Sendable {
 		self.fileExtension = fileExtension
 	}
 
-	public func url(filename: String) -> URL {
+	public func url(filename: String, directory: String) -> URL {
 		return
-			outputDirectory
+			URL(fileURLWithPath: directory, relativeTo: outputDirectory)
 			.appending(path: filename)
 			.appendingPathExtension(fileExtension)
 	}
 
 	@inlinable @inline(__always)
-	public func callAsFunction(filename: String) -> URL {
-		return url(filename: filename)
+	public func callAsFunction(filename: String, directory: String) -> URL {
+		return url(filename: filename, directory: directory)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/ImageEvaluatorConfiguration.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/ImageEvaluatorConfiguration.swift
@@ -1,0 +1,15 @@
+public struct ImageEvaluationConfiguration: Equatable, Hashable, Sendable {
+	public let fileExtension: String
+	public let directory: String
+	public let filenamePattern: String
+
+	public init(
+		fileExtension: String,
+		directory: String,
+		filenamePattern: String
+	) {
+		self.fileExtension = fileExtension
+		self.directory = directory
+		self.filenamePattern = filenamePattern
+	}
+}

--- a/Sources/MarkdownBabel/Execute/Execute.swift
+++ b/Sources/MarkdownBabel/Execute/Execute.swift
@@ -1,3 +1,5 @@
+import struct Foundation.URL
+
 public struct Execute {
 	let executableContext: ExecutableContext
 	let evaluator: any Evaluator
@@ -11,14 +13,14 @@ public struct Execute {
 	}
 
 	@inlinable @inline(__always)
-	public func callAsFunction() async -> Response {
-		return await execute()
+	public func callAsFunction(sourceURL: URL?) async -> Response {
+		return await execute(sourceURL: sourceURL)
 	}
 
-	public func execute() async -> Response {
+	public func execute(sourceURL: URL?) async -> Response {
 		let result: Execute.Response.ExecutionResult
 		do {
-			let output = try await evaluator.run(executableContext.codeBlock.code)
+			let output = try await evaluator.run(executableContext.codeBlock.code, sourceURL: sourceURL)
 			result = .init(output: output, error: nil)
 		} catch {
 			result = .init(output: nil, error: "\(error)")

--- a/Sources/MarkdownBabel/Execute/Execute.swift
+++ b/Sources/MarkdownBabel/Execute/Execute.swift
@@ -1,10 +1,10 @@
 public struct Execute {
 	let executableContext: ExecutableContext
-	let evaluator: Evaluator
+	let evaluator: any Evaluator
 
 	public init(
 		executableContext: ExecutableContext,
-		evaluator: Evaluator
+		evaluator: any Evaluator
 	) {
 		self.executableContext = executableContext
 		self.evaluator = evaluator
@@ -16,7 +16,14 @@ public struct Execute {
 	}
 
 	public func execute() async -> Response {
-		let result = await evaluator.result(fromRunning: executableContext.codeBlock.code)
+		let result: Execute.Response.ExecutionResult
+		do {
+			let output = try await evaluator.run(executableContext.codeBlock.code)
+			result = .init(output: output, error: nil)
+		} catch {
+			result = .init(output: nil, error: "\(error)")
+		}
+
 		return Response(
 			executableContext: executableContext,
 			executionResult: result

--- a/Sources/MarkdownBabel/FilenamePattern.swift
+++ b/Sources/MarkdownBabel/FilenamePattern.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// - Parameters:
+///   - pattern: [Unicode TR-35](https://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns) pattern. Enquote literal string parts with single quotes; everything else may be interpreted as a date format pattern.
+///   - sourceFilename: Will be inserted in place of occurrences of "`$fn`" in `pattern`.
+///   - contentHash: Will be inserted in place of occurrences of "`$hash`" in `pattern`.
+///   - locale: Locale used for date formatting. Defaults to `en_US_POSIX`.
+///   - now: Returns the date that represents the current date and time at the moment of the function call. (Testing seam.)
+/// - Returns: Formatted string.
+public func filename(
+	pattern: String,
+	sourceFilename: String,
+	contentHash: String,
+	locale: Locale = Locale(identifier: "en_US_POSIX"),
+	now: () -> Date = { Date.now }
+) -> String {
+	let formatter = DateFormatter()
+	formatter.locale = locale
+	formatter.dateFormat = pattern
+	return
+		formatter
+		.string(from: now())
+		.replacing("$fn", with: sourceFilename)
+		.replacing("$hash", with: contentHash)
+}

--- a/Sources/md-babel/Execute/ExecuteCommand.swift
+++ b/Sources/md-babel/Execute/ExecuteCommand.swift
@@ -141,6 +141,7 @@ extension ExecuteCommand {
 func perform(sideEffect: SideEffect?) throws {
 	switch sideEffect {
 	case .writeFile(let data, let url):
+		try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 		try data.write(to: url)
 	case .none:
 		break

--- a/Sources/md-babel/Execute/ExecuteCommand.swift
+++ b/Sources/md-babel/Execute/ExecuteCommand.swift
@@ -85,8 +85,8 @@ struct ExecuteCommand: AsyncParsableCommand {
 			FileHandle.standardOutput.write(try JSON.object([:]).data())
 			return
 		}
-		let evaluator = Evaluator(
-			configuration: try evaluatorRegistry().configuration(forCodeBlock: context.codeBlock),
+		let configuration = try evaluatorRegistry().configuration(forCodeBlock: context.codeBlock)
+		let evaluator = configuration.makeEvaluator(
 			generateImageFileURL: GenerateImageFileURL(
 				outputDirectory: try outputDirectory(),
 				fileExtension: "svg"  // TODO: Make file extension configurable in converter https://github.com/md-babel/swift-markdown-babel/issues/20

--- a/Sources/md-babel/Execute/ExecuteCommand.swift
+++ b/Sources/md-babel/Execute/ExecuteCommand.swift
@@ -93,7 +93,7 @@ struct ExecuteCommand: AsyncParsableCommand {
 			)
 		)
 		let execute = Execute(executableContext: context, evaluator: evaluator)
-		let response = await execute()
+		let response = await execute(sourceURL: inputFile)
 
 		try perform(sideEffect: response.executionResult.output?.sideEffect)
 

--- a/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
+++ b/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
@@ -45,7 +45,12 @@ import Testing
 			  "dot": {
 			    "path": "/usr/bin/env",
 			    "defaultArguments": ["dot", "-Tsvg"],
-			    "result": "image"
+			    "result": {
+			      "type": "image",
+			      "directory": "/tmp/dir",
+			      "pattern": "filename",
+			      "extension": "svg"
+			    }
 			  },
 			  "python": {
 			    "path": "/usr/bin/env",
@@ -68,7 +73,7 @@ import Testing
 					executablePath: "/usr/bin/env",
 					arguments: ["dot", "-Tsvg"],
 					executableMarkupType: .codeBlock(language: "dot"),
-					resultMarkupType: .image
+					resultMarkupType: .image(fileExtension: "svg", directory: "/tmp/dir", filenamePattern: "filename")
 				),
 				.codeBlock(language: "python"): EvaluatorConfiguration(
 					executablePath: "/usr/bin/env",

--- a/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
+++ b/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
@@ -48,7 +48,7 @@ import Testing
 			    "result": {
 			      "type": "image",
 			      "directory": "/tmp/dir",
-			      "pattern": "filename",
+			      "filename": "a filename pattern",
 			      "extension": "svg"
 			    }
 			  },
@@ -73,7 +73,11 @@ import Testing
 					executablePath: "/usr/bin/env",
 					arguments: ["dot", "-Tsvg"],
 					executableMarkupType: .codeBlock(language: "dot"),
-					resultMarkupType: .image(fileExtension: "svg", directory: "/tmp/dir", filenamePattern: "filename")
+					resultMarkupType: .image(
+						fileExtension: "svg",
+						directory: "/tmp/dir",
+						filenamePattern: "a filename pattern"
+					)
 				),
 				.codeBlock(language: "python"): EvaluatorConfiguration(
 					executablePath: "/usr/bin/env",

--- a/Tests/MarkdownBabelTests/FilenamePatternTests.swift
+++ b/Tests/MarkdownBabelTests/FilenamePatternTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import MarkdownBabel
+import Testing
+
+private let irrelevantFilename = "irrelevant"
+private let irrelevantContentHash = "16n0r3d"
+private let nowStub: @Sendable () -> Date = { Date(timeIntervalSince1970: 1_757_230_512) }
+
+private func fn(
+	pattern: String,
+	sourceFilename: String = irrelevantFilename,
+	contentHash: String = irrelevantContentHash,
+	localeIdentifier: String = "en_US_POSIX"
+) -> String {
+	return filename(
+		pattern: pattern,
+		sourceFilename: sourceFilename,
+		contentHash: contentHash,
+		locale: Locale(identifier: localeIdentifier),
+		now: nowStub
+	)
+}
+
+@Suite struct FilenamePatternTests {
+	@Test(arguments: [
+		("", ""),
+		("''", "'"),
+		("''''", "''"),
+		("'o''clock'", "o'clock"),
+		("'fn'", "fn"),
+		("'hash'", "hash"),
+		("'test file'", "test file"),
+		("'yyyy'", "yyyy"),
+	]) func staticStringReturnsItself(pattern: String, expectedFilename: String) {
+		#expect(fn(pattern: pattern) == expectedFilename)
+	}
+
+	@Test func filenameOutsideOfQuotes() {
+		#expect(fn(pattern: "$fn") == "$")
+	}
+
+	@Test(arguments: [
+		("'$fn'", "a 'replacement' filename"),
+		("'\\$fn'", "\\a 'replacement' filename"),  // There is no escape
+		("'prefix $fn'", "prefix a 'replacement' filename"),
+		("'$fn suffix'", "a 'replacement' filename suffix"),
+		("'in $fn fix'", "in a 'replacement' filename fix"),
+	]) func filenameOnly(pattern: String, expectedFilename: String) {
+		#expect(fn(pattern: pattern, sourceFilename: "a 'replacement' filename") == expectedFilename)
+	}
+
+	@Test(arguments: [
+		("'$hash'", "d34db33f"),
+		("'\\$hash'", "\\d34db33f"),  // There is no escape
+		("'prefix $hash'", "prefix d34db33f"),
+		("'$hash suffix'", "d34db33f suffix"),
+		("'in $hash fix'", "in d34db33f fix"),
+	]) func hashOnly(pattern: String, expectedFilename: String) {
+		#expect(fn(pattern: pattern, contentHash: "d34db33f") == expectedFilename)
+	}
+
+	@Test(arguments: [
+		("en_US_POSIX", "September"),
+		("en_US", "September"),
+		("fr_FR", "septembre"),
+		("de_DE", "September"),
+		("ko_KR", "9월"),
+	]) func localizedDate(localeIdentifier: String, expectedFilename: String) {
+		#expect(fn(pattern: "LLLL", localeIdentifier: localeIdentifier) == expectedFilename)
+	}
+
+	@Test(arguments: [
+		("yyyyMMdd'T'HHmmss'--$fn__$hash'", "20250907T093512--Weird yyyy Filename__d34db33f"),
+		("yyyyMMdd '$fn'", "20250907 Weird yyyy Filename"),
+		("'rendered-$hash'", "rendered-d34db33f"),
+	]) func mixedRealWorldPatterns(pattern: String, expectedFilename: String) {
+		#expect(
+			fn(pattern: pattern, sourceFilename: "Weird yyyy Filename", contentHash: "d34db33f")
+				== expectedFilename
+		)
+	}
+}


### PR DESCRIPTION
My personal Mermaid configuration looks like this:

	  "mermaid": {
		"path": "/Users/ctm/.asdf/installs/nodejs/23.3.0/bin/mmdc",
		"defaultArguments": [
		  "--input", "-",
		  "--outputFormat", "svg",
		  "--output", "-"
		],
		"result": {
		  "type": "image",
		  "extension": "svg",
		  "directory": "./images/",
		  "filename": "yyyyMMddHHmmss'--$fn__$hash'"
		}
      }

Given 

    $ swift run md-babel exec --file test.txt --line 24 --column 1 --config config.json

it produces the output file path:

    /var/folders/62/8k21681d08z9lhq8h433z3rh0000gp/T/images/20250415112038--test__f182501c5d89032ae50808b46416736400db67f9127e45e981ed2b0b30ad2ea8.svg

Closes #20.