### PR TITLE
Skip (expensive) image rendering if content hash is the same.

### DIFF
--- a/Sources/MarkdownBabel/ExecutableContext/ImageResult.swift
+++ b/Sources/MarkdownBabel/ExecutableContext/ImageResult.swift
@@ -6,12 +6,15 @@ public struct ImageResult: ResultMarkup {
 
 	public let title: String
 	public let source: String
+	public let alt: String
+	public var contentHash: String { alt }
 	public var content: String { source }
 	public let range: SourceRange
 
 	public init(_ base: DocumentEmbedded<ImageParagraph>) {
 		self.title = base.markup.image.title ?? ""
 		self.source = base.markup.image.source ?? ""
+		self.alt = base.markup.alt
 		self._debugDescription = { base.markup.debugDescription(options: $0) }
 		self._nextSibling = { base.markup.nextSibling() }
 		self.range = base.range

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToCodeEvaluator.swift
@@ -9,9 +9,11 @@ public struct CodeToCodeEvaluator: Evaluator, Sendable {
 	}
 
 	public func run(
-		_ code: String,
+		_ executableContext: ExecutableContext,
 		sourceURL: URL?
 	) async throws -> Execute.Response.ExecutionResult.Output {
+		let code = executableContext.codeBlock.code
+
 		let (terminationStatus, outputData) = try await runProcess(
 			configuration: self.configuration,
 			standardInput: code

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -19,9 +19,11 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 	}
 
 	public func run(
-		_ code: String,
+		_ executableContext: ExecutableContext,
 		sourceURL: URL?
 	) async throws -> Execute.Response.ExecutionResult.Output {
+		let code = executableContext.codeBlock.code
+
 		guard let hashContent = ContentHash(string: code, encoding: .utf8)
 		else { throw ExecutionFailure.hashingContentFailed(code) }
 

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -27,6 +27,15 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 		guard let hashContent = ContentHash(string: code, encoding: .utf8)
 		else { throw ExecutionFailure.hashingContentFailed(code) }
 
+		if let existingImageResult = executableContext.result?.content as? ImageResult,
+			hashContent.contentHash() == existingImageResult.contentHash
+		{
+			return .init(
+				insert: .image(path: existingImageResult.source, hash: existingImageResult.contentHash),
+				sideEffect: nil
+			)
+		}
+
 		let (_, outputData) = try await runProcess(
 			configuration: self.configuration,
 			standardInput: code

--- a/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/Evaluator.swift
@@ -3,7 +3,7 @@ import struct Foundation.URL
 
 public protocol Evaluator: Sendable {
 	func run(
-		_ input: String,
+		_ executableContext: ExecutableContext,
 		sourceURL: URL?
 	) async throws -> Execute.Response.ExecutionResult.Output
 }

--- a/Sources/MarkdownBabel/Execute/Execute.swift
+++ b/Sources/MarkdownBabel/Execute/Execute.swift
@@ -20,7 +20,7 @@ public struct Execute {
 	public func execute(sourceURL: URL?) async -> Response {
 		let result: Execute.Response.ExecutionResult
 		do {
-			let output = try await evaluator.run(executableContext.codeBlock.code, sourceURL: sourceURL)
+			let output = try await evaluator.run(executableContext, sourceURL: sourceURL)
 			result = .init(output: output, error: nil)
 		} catch {
 			result = .init(output: nil, error: "\(error)")


### PR DESCRIPTION
Closes #27