### PR TITLE
Relativize image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,29 @@ In any case, all calls are routed through `md-babel` as your executable Markdown
 
     Usage: md-babel execute [--file <file>] --line <line> --column <column> [--dir </path/to/project>] [--config <config>] [--no-load-user-config]
 
-1. Grab the the code block from `<file>` (or standard input) at/around `<line>:<column>` (starting at 1, not 0, to meet CommonMark standards), 
-2. execute it in its context,
-3. and produce a [md-babel:execute-block:response][execute-block-schema]-formatted JSON to stdandard output.
+1.  Grab the the code block from `<file>` (or standard input) at/around `<line>:<column>` (starting at 1, not 0, to meet CommonMark standards), 
+2.  execute it in its context,
+3.  and produce a [md-babel:execute-block:response][execute-block-schema]-formatted JSON to stdandard output.
 
-The optional `--config` uses a separate environment configuration file that is merged with the user's global configuration.
+    Client editors can then process rhe resulting JSON response to insert the result of the code block. 
+    See for [a reference implementation in Emacs][md-babel.el] or [the Visual Studio Code plugin][vscode].
+    
+Other options:
 
-The optional `--dir` can be used to use relative instead of absolute paths for build products from code blocks, including images.
-Editors set this to the project or workspace directory to put assets in a common folder.
-
-Client editors can then process this to insert the result of the code block. 
-See [md-babel.el][] for an implementation in Emacs.
+-   The `--no-load-user-config` flag determines whether the [global configuration file](#configuration-file) should be used.
+    If you toggle this but then don't pass a `--config` file path to use instead, no code block evaluators will be known.
+-   The optional `--config` argument loads a configuration file that is merged with the user's global configuration by default. 
+    If you combine this with `--no-load-user-config`, only the config file you pass here will be used.
+-   The optional `--dir` can be used to use relative instead of absolute paths for build products from code blocks, including images.
+    Editors set this to the project or workspace directory to put assets in a common folder.
+  
+    The effective evaluator configuration should _not_ use absolute output `"directory"` keys for relative paths to work. 
+    Leaving the `"directory"` key out completely will put images in the project root; 
+    using relative directives like `"directory": "./assets"` will put them in a shared subdirectory.
 
 [execute-block-schema]: https://github.com/md-babel/md-babel-schema/tree/main/execute-block
 [md-babel.el]: https://github.com/md-babel/md-babel.el
+[vscode]: https://github.com/md-babel/vscode-md-babel
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ In any case, all calls are routed through `md-babel` as your executable Markdown
 
 ### Execute Block
 
-    Usage: md-babel execute [--file <file>] --line <line> --column <column> [--no-load-user-config] [--config <config>]
+    Usage: md-babel execute [--file <file>] --line <line> --column <column> [--dir </path/to/project>] [--config <config>] [--no-load-user-config]
 
 1. Grab the the code block from `<file>` (or standard input) at/around `<line>:<column>` (starting at 1, not 0, to meet CommonMark standards), 
 2. execute it in its context,
 3. and produce a [md-babel:execute-block:response][execute-block-schema]-formatted JSON to stdandard output.
 
 The optional `--config` uses a separate environment configuration file that is merged with the user's global configuration.
+
+The optional `--dir` can be used to use relative instead of absolute paths for build products from code blocks, including images.
+Editors set this to the project or workspace directory to put assets in a common folder.
 
 Client editors can then process this to insert the result of the code block. 
 See [md-babel.el][] for an implementation in Emacs.
@@ -131,6 +134,8 @@ Here's a simple example for shell scripts and Python:
 
 If you can rely on `/usr/bin/env`, like with hash-bangs, you can set and forget it. 
 (With pyenv, rbenv, asdf, ... your mileage may vary!)
+
+[See the examples file](Examples.md) to learn how to configure various evaluators.
 
 [config-schema]: https://github.com/md-babel/md-babel-schema/tree/main/config
 

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -49,11 +49,7 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 			sourceFilename: sourceFilename,
 			contentHash: contentHash.digest
 		)
-		let imageFileURL = generateImageFileURL(
-			filename: filename,
-			imageConfiguration: imageConfiguration,
-			relativizePath: false
-		)
+		let imageFileURL = generateImageFileURL(filename: filename, imageConfiguration: imageConfiguration)
 		return .init(
 			insert: .image(path: imageFileURL.path(), hash: contentHash.digest),
 			sideEffect: .writeFile(outputData, to: imageFileURL.fileURL)

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -49,10 +49,14 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 			sourceFilename: sourceFilename,
 			contentHash: contentHash.digest
 		)
-		let imageURL: URL = generateImageFileURL(filename: filename, imageConfiguration: imageConfiguration)
+		let imageFileURL = generateImageFileURL(
+			filename: filename,
+			imageConfiguration: imageConfiguration,
+			relativizePath: false
+		)
 		return .init(
-			insert: .image(path: imageURL.absoluteURL.path, hash: contentHash.digest),
-			sideEffect: .writeFile(outputData, to: imageURL)
+			insert: .image(path: imageFileURL.path(), hash: contentHash.digest),
+			sideEffect: .writeFile(outputData, to: imageFileURL.fileURL)
 		)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/CodeToImageEvaluator.swift
@@ -42,6 +42,7 @@ public struct CodeToImageEvaluator: Evaluator, Sendable {
 
 		let (_, outputData) = try await runProcess(input: code, additionalArguments: [])
 
+		// TODO: Introduce a --filename cli argument to set the filename even when passing in content via stdin: https://github.com/md-babel/swift-markdown-babel/issues/37
 		let sourceFilename = sourceURL?.deletingPathExtension().lastPathComponent ?? "STDIN"
 		let filename = filename(
 			pattern: imageConfiguration.filenamePattern,

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluationResultMarkup.swift
@@ -11,7 +11,7 @@ public enum EvaluationResultMarkup: Hashable, Sendable {
 
 	public static func image(
 		fileExtension: String,
-		directory: String,
+		directory: String?,
 		filenamePattern: String
 	) -> EvaluationResultMarkup {
 		return .image(.init(fileExtension: fileExtension, directory: directory, filenamePattern: filenamePattern))
@@ -24,7 +24,7 @@ extension EvaluationResultMarkup: CustomStringConvertible {
 		case .codeBlock:
 			"code block"
 		case .image(let config):
-			"image (\(config.directory)/\(config.filenamePattern).\(config.fileExtension))"
+			"image (\(config))"
 		}
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration+json.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration+json.swift
@@ -34,7 +34,7 @@ extension EvaluatorConfiguration {
 		case .right(let dictionary) where dictionary["type"] == "image":
 			resultMarkupType = .image(
 				fileExtension: try dictionary.ensureValue("extension"),
-				directory: try dictionary.ensureValue("directory"),
+				directory: dictionary["directory"],
 				filenamePattern: try dictionary.ensureValue("filename")
 			)
 		default:
@@ -54,12 +54,14 @@ extension EvaluatorConfiguration {
 			switch self.resultMarkupType {
 			case .codeBlock: .left("codeBlock")
 			case .image(let config):
-				.right([
-					"type": "image",
-					"extension": config.fileExtension,
-					"directory": config.directory,
-					"filename": config.filenamePattern,
-				])
+				.right(
+					[
+						"type": "image",
+						"extension": config.fileExtension,
+						"directory": config.directory,
+						"filename": config.filenamePattern,
+					].compactMapValues { $0 }
+				)
 			}
 		let rep = Representation(
 			path: self.executableURL.path(),

--- a/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/EvaluatorConfiguration.swift
@@ -45,7 +45,8 @@ extension EvaluatorConfiguration {
 
 extension EvaluatorConfiguration {
 	public func makeEvaluator(
-		outputDirectory: URL
+		outputDirectory: URL,
+		relativizePaths: Bool
 	) -> any Evaluator {
 		switch (self.executableMarkupType, self.resultMarkupType) {
 		case (.codeBlock, .codeBlock):
@@ -55,7 +56,8 @@ extension EvaluatorConfiguration {
 				runProcess: self.makeRunProcess(),
 				imageConfiguration: imageConfiguration,
 				generateImageFileURL: GenerateImageFileURL(
-					outputDirectory: outputDirectory
+					outputDirectory: outputDirectory,
+					relativizePaths: relativizePaths
 				)
 			)
 		}

--- a/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
@@ -7,37 +7,69 @@ public struct GenerateImageFileURL: Equatable, Sendable {
 		self.outputDirectory = outputDirectory
 	}
 
-	public func url(filename: String, fileExtension: String, directory: String?) -> URL {
+	public func url(
+		filename: String,
+		fileExtension: String,
+		directory: String?,
+		relativizePath: Bool
+	) -> ImageFileURL {
 		let baseDirectory =
 			if let directory {
 				URL(fileURLWithPath: directory, relativeTo: outputDirectory)
 			} else {
 				outputDirectory
 			}
-		return
+		let fileURL =
 			baseDirectory
 			.appending(path: filename)
 			.appendingPathExtension(fileExtension)
+		return ImageFileURL(
+			fileURL: fileURL,
+			relativizigWorkingDirectory: relativizePath ? outputDirectory : nil
+		)
 	}
 
 	@inlinable @inline(__always)
-	public func callAsFunction(filename: String, fileExtension: String, directory: String?) -> URL {
-		return url(filename: filename, fileExtension: fileExtension, directory: directory)
+	public func callAsFunction(
+		filename: String,
+		fileExtension: String,
+		directory: String?,
+		relativizePath: Bool
+	) -> ImageFileURL {
+		return url(
+			filename: filename,
+			fileExtension: fileExtension,
+			directory: directory,
+			relativizePath: relativizePath
+		)
 	}
 }
 
 extension GenerateImageFileURL {
 	@inlinable @inline(__always)
-	public func url(filename: String, imageConfiguration: ImageEvaluationConfiguration) -> URL {
+	public func url(
+		filename: String,
+		imageConfiguration: ImageEvaluationConfiguration,
+		relativizePath: Bool
+	) -> ImageFileURL {
 		return url(
 			filename: filename,
 			fileExtension: imageConfiguration.fileExtension,
-			directory: imageConfiguration.directory
+			directory: imageConfiguration.directory,
+			relativizePath: relativizePath
 		)
 	}
 
 	@inlinable @inline(__always)
-	public func callAsFunction(filename: String, imageConfiguration: ImageEvaluationConfiguration) -> URL {
-		return url(filename: filename, imageConfiguration: imageConfiguration)
+	public func callAsFunction(
+		filename: String,
+		imageConfiguration: ImageEvaluationConfiguration,
+		relativizePath: Bool
+	) -> ImageFileURL {
+		return url(
+			filename: filename,
+			imageConfiguration: imageConfiguration,
+			relativizePath: relativizePath
+		)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
@@ -7,15 +7,21 @@ public struct GenerateImageFileURL: Equatable, Sendable {
 		self.outputDirectory = outputDirectory
 	}
 
-	public func url(filename: String, fileExtension: String, directory: String) -> URL {
+	public func url(filename: String, fileExtension: String, directory: String?) -> URL {
+		let baseDirectory =
+			if let directory {
+				URL(fileURLWithPath: directory, relativeTo: outputDirectory)
+			} else {
+				outputDirectory
+			}
 		return
-			URL(fileURLWithPath: directory, relativeTo: outputDirectory)
+			baseDirectory
 			.appending(path: filename)
 			.appendingPathExtension(fileExtension)
 	}
 
 	@inlinable @inline(__always)
-	public func callAsFunction(filename: String, fileExtension: String, directory: String) -> URL {
+	public func callAsFunction(filename: String, fileExtension: String, directory: String?) -> URL {
 		return url(filename: filename, fileExtension: fileExtension, directory: directory)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/GenerateImageFileURL.swift
@@ -2,16 +2,20 @@ import struct Foundation.URL
 
 public struct GenerateImageFileURL: Equatable, Sendable {
 	public let outputDirectory: URL
+	public let relativizePaths: Bool
 
-	public init(outputDirectory: URL) {
+	public init(
+		outputDirectory: URL,
+		relativizePaths: Bool
+	) {
 		self.outputDirectory = outputDirectory
+		self.relativizePaths = relativizePaths
 	}
 
 	public func url(
 		filename: String,
 		fileExtension: String,
-		directory: String?,
-		relativizePath: Bool
+		directory: String?
 	) -> ImageFileURL {
 		let baseDirectory =
 			if let directory {
@@ -25,7 +29,7 @@ public struct GenerateImageFileURL: Equatable, Sendable {
 			.appendingPathExtension(fileExtension)
 		return ImageFileURL(
 			fileURL: fileURL,
-			relativizigWorkingDirectory: relativizePath ? outputDirectory : nil
+			relativizigWorkingDirectory: relativizePaths ? outputDirectory : nil
 		)
 	}
 
@@ -33,14 +37,12 @@ public struct GenerateImageFileURL: Equatable, Sendable {
 	public func callAsFunction(
 		filename: String,
 		fileExtension: String,
-		directory: String?,
-		relativizePath: Bool
+		directory: String?
 	) -> ImageFileURL {
 		return url(
 			filename: filename,
 			fileExtension: fileExtension,
-			directory: directory,
-			relativizePath: relativizePath
+			directory: directory
 		)
 	}
 }
@@ -49,27 +51,23 @@ extension GenerateImageFileURL {
 	@inlinable @inline(__always)
 	public func url(
 		filename: String,
-		imageConfiguration: ImageEvaluationConfiguration,
-		relativizePath: Bool
+		imageConfiguration: ImageEvaluationConfiguration
 	) -> ImageFileURL {
 		return url(
 			filename: filename,
 			fileExtension: imageConfiguration.fileExtension,
-			directory: imageConfiguration.directory,
-			relativizePath: relativizePath
+			directory: imageConfiguration.directory
 		)
 	}
 
 	@inlinable @inline(__always)
 	public func callAsFunction(
 		filename: String,
-		imageConfiguration: ImageEvaluationConfiguration,
-		relativizePath: Bool
+		imageConfiguration: ImageEvaluationConfiguration
 	) -> ImageFileURL {
 		return url(
 			filename: filename,
-			imageConfiguration: imageConfiguration,
-			relativizePath: relativizePath
+			imageConfiguration: imageConfiguration
 		)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/ImageEvaluatorConfiguration.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/ImageEvaluatorConfiguration.swift
@@ -1,15 +1,26 @@
 public struct ImageEvaluationConfiguration: Equatable, Hashable, Sendable {
 	public let fileExtension: String
-	public let directory: String
+	public let directory: String?
 	public let filenamePattern: String
 
 	public init(
 		fileExtension: String,
-		directory: String,
+		directory: String?,
 		filenamePattern: String
 	) {
 		self.fileExtension = fileExtension
 		self.directory = directory
 		self.filenamePattern = filenamePattern
+	}
+}
+
+extension ImageEvaluationConfiguration: CustomStringConvertible {
+	public var description: String {
+		return [
+			directory,
+			"\(filenamePattern).\(fileExtension)",
+		]
+		.compactMap { $0 }
+		.joined(separator: "/")
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/ImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/ImageFileURL.swift
@@ -17,9 +17,9 @@ public struct ImageFileURL: Equatable, Sendable {
 
 	public func path() -> String {
 		guard let relativizigWorkingDirectory else {
-			return fileURL.path()
+			return fileURL.absoluteURL.path()
 		}
 
-		return fileURL.relativePath(resolvedAgainst: relativizigWorkingDirectory)
+		return fileURL.absoluteURL.relativePath(resolvedAgainst: relativizigWorkingDirectory)
 	}
 }

--- a/Sources/MarkdownBabel/Execute/Evaluator/ImageFileURL.swift
+++ b/Sources/MarkdownBabel/Execute/Evaluator/ImageFileURL.swift
@@ -1,0 +1,25 @@
+import struct Foundation.URL
+
+public struct ImageFileURL: Equatable, Sendable {
+	/// Absolute file URL of the image.
+	public let fileURL: URL
+
+	/// Base directory used to resolve ``path()`` as relative. `nil` denotes absolute paths.
+	public let relativizigWorkingDirectory: URL?
+
+	public init(
+		fileURL: URL,
+		relativizigWorkingDirectory: URL? = nil
+	) {
+		self.fileURL = fileURL
+		self.relativizigWorkingDirectory = relativizigWorkingDirectory
+	}
+
+	public func path() -> String {
+		guard let relativizigWorkingDirectory else {
+			return fileURL.path()
+		}
+
+		return fileURL.relativePath(resolvedAgainst: relativizigWorkingDirectory)
+	}
+}

--- a/Sources/MarkdownBabel/URL+relativePath.swift
+++ b/Sources/MarkdownBabel/URL+relativePath.swift
@@ -1,0 +1,84 @@
+import struct Foundation.URL
+
+extension Array where Element: Equatable {
+	fileprivate func commonPrefix(_ other: [Element]) -> [Element] {
+		var result: [Element] = []
+		for (lhs, rhs) in zip(self, other) {
+			guard lhs == rhs else {
+				break
+			}
+			result.append(lhs)
+		}
+		return result
+	}
+}
+
+extension URL {
+	/// Produces a relative path to get from `baseURL` to the receiver for use in e.g. labels.
+	///
+	/// When there's no common ancestor, e.g. `/tmp/` and `/var/`, then this returns an absolute path. The only exception to this rule is when `baseURL` itself is the root `/`, since tor that base _all_ paths are relative.
+	///
+	/// - Returns: Shortest relative path to get from `baseURL` to receiver, e.g. `"../../subdirectory/file.txt"`, and `"."` if both are identical. Absolute path (or absolute URL for non-`file://` URLs) if there's nothing in common.
+	package func relativePath(resolvedAgainst baseURL: URL) -> String {
+		guard let url = self.relativeURL(resolvedAgainst: baseURL) else {
+			if self.isFileURL {
+				// Produce absolute file path
+				return self.path
+			} else if self.scheme == baseURL.scheme && self.host == baseURL.host {
+				// For e.g. web URLs, if protocol and domain are the same, drop the shared part and return only the absolute path.
+				return self.path
+			} else {
+				// If everything differs in non-file URLs, produce the whole URL string.
+				return self.absoluteString
+			}
+		}
+
+		let path = url.relativePath
+		guard path.hasPrefix("./") else {
+			return path
+		}
+		// Avoid "./file.txt" and "./../sibling/path.txt" by dropping the current dir part.
+		return String(path.dropFirst(2))
+	}
+
+	/// - Returns: `nil` if the URLs cannot be compared (e.g. file vs http scheme) or have nothing in common.
+	private func relativeURL(resolvedAgainst baseURL: URL) -> URL? {
+		// Protect against cross-domain or cross-scheme URL comparison attempts.
+		guard self.scheme == baseURL.scheme,
+			self.host == baseURL.host
+		else {
+			return nil
+		}
+
+		// Ignore file in base directory path.
+		guard baseURL.hasDirectoryPath else {
+			return self.relativeURL(resolvedAgainst: baseURL.deletingLastPathComponent())
+		}
+
+		// Ignore the file when comparing the reference URL (self) to baseURL, but do preserve the file for a full path.
+		guard self.hasDirectoryPath else {
+			// Append target file name to result to get not just the path directions, but the total result. The use of an array and filter gets rid of empty `resolvedDirectoryPath` strings in one go, i.e when the base directory and the current directory are one and the same.
+			return self.deletingLastPathComponent()
+				.relativeURL(resolvedAgainst: baseURL)?
+				.appendingPathComponent(self.lastPathComponent)
+		}
+
+		// We can rely on `pathComponents` producing absolute paths: even when using the relative URL initializer, `pathComponents` are resolved using the implicit base URL during initialization (for Xcode tests, that's the derived data path, and in the Swift REPL the working directory of the shell).
+		let sharedPathComponents = self.pathComponents.commonPrefix(baseURL.pathComponents)
+
+		// No path component in common with `baseURL`. (Except when base is root.)
+		if sharedPathComponents == ["/"]
+			&& baseURL.pathComponents != ["/"]
+		{
+			return nil
+		}
+
+		let uniqueBasePathComponents = baseURL.pathComponents.dropFirst(sharedPathComponents.count)
+		let uniqueReferencePathComponents = self.pathComponents.dropFirst(sharedPathComponents.count)
+
+		let goToParent = uniqueBasePathComponents.map { _ in ".." }
+		let drillDownToPath = uniqueReferencePathComponents
+		return (goToParent + drillDownToPath)
+			.reduce(URL(fileURLWithPath: "", relativeTo: baseURL)) { $0.appendingPathComponent($1) }
+	}
+}

--- a/Sources/md-babel/Execute/ExecuteCommand.swift
+++ b/Sources/md-babel/Execute/ExecuteCommand.swift
@@ -55,7 +55,7 @@ struct ExecuteCommand: AsyncParsableCommand {
 	@Option(
 		name: [.customShort("d"), .customLong("dir")],
 		help: ArgumentHelp(
-			"Working directory used to resolve relative paths. ",
+			"Working directory used to resolve relative paths.",
 			discussion:
 				"""
 				Compiler and image generator configurations can use relative paths to put build
@@ -66,6 +66,7 @@ struct ExecuteCommand: AsyncParsableCommand {
 		)
 	)
 	var workingDirectoryPath: String?
+	var relativizePaths: Bool { workingDirectoryPath != nil }
 
 	// MARK: - Config File
 
@@ -108,7 +109,8 @@ struct ExecuteCommand: AsyncParsableCommand {
 		let configuration = try evaluatorRegistry().configuration(forCodeBlock: context.codeBlock)
 		let evaluator = configuration.makeEvaluator(
 			// TODO: Use output path command-lind argument https://github.com/md-babel/swift-markdown-babel/issues/34
-			outputDirectory: try outputDirectory()
+			outputDirectory: try outputDirectory(),
+			relativizePaths: relativizePaths
 		)
 		let execute = Execute(executableContext: context, evaluator: evaluator)
 		let response = await execute(sourceURL: inputFile)

--- a/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
+++ b/Tests/MarkdownBabelTests/EvaluatorConfigurationTests.swift
@@ -100,12 +100,20 @@ import Testing
 				resultMarkupType: .codeBlock
 			)
 			let baseDir = URL(filePath: "/out/dir/")
-			let evaluator = try #require(configuration.makeEvaluator(outputDirectory: baseDir) as? CodeToCodeEvaluator)
+			let evaluator = try #require(
+				configuration.makeEvaluator(
+					outputDirectory: baseDir,
+					relativizePaths: false  // Irrelevant/unused in this evaluator
+				) as? CodeToCodeEvaluator
+			)
 			#expect(evaluator.executableURL == URL(filePath: "/file/path"))
 			#expect(evaluator.defaultArguments == ["a", "b"])
 		}
 
-		@Test func codeToImage() throws {
+		@Test(arguments: [
+			true,
+			false,
+		]) func codeToImage(relativizePaths: Bool) throws {
 			let imageConfig = ImageEvaluationConfiguration(
 				fileExtension: "tiff",
 				directory: "./subdir/",
@@ -119,10 +127,14 @@ import Testing
 			)
 			let baseDir = URL(filePath: "/out/dir/")
 			let evaluator = try #require(
-				configuration.makeEvaluator(outputDirectory: baseDir) as? CodeToImageEvaluator
+				configuration.makeEvaluator(
+					outputDirectory: baseDir,
+					relativizePaths: relativizePaths
+				) as? CodeToImageEvaluator
 			)
 			let expectedGenerator = GenerateImageFileURL(
-				outputDirectory: baseDir
+				outputDirectory: baseDir,
+				relativizePaths: relativizePaths
 			)
 			#expect(evaluator.imageConfiguration == imageConfig)
 			#expect(evaluator.generateImageFileURL == expectedGenerator)

--- a/Tests/MarkdownBabelTests/ImageFileURLTests.swift
+++ b/Tests/MarkdownBabelTests/ImageFileURLTests.swift
@@ -1,0 +1,63 @@
+import MarkdownBabel
+import Testing
+
+import struct Foundation.URL
+
+@Suite("ImageFileURL")
+struct ImageFileURLTests {
+	@Suite("path()") struct PathTests {
+		@Test("absolute file URL without base dir")
+		func pathWithAbsoluteURL() throws {
+			let imageURL = ImageFileURL(
+				fileURL: URL(filePath: "/Users/test/images/photo.jpg"),
+				relativizigWorkingDirectory: nil
+			)
+
+			#expect(imageURL.path() == "/Users/test/images/photo.jpg")
+		}
+
+		@Suite("relative to base directory") struct Relativizing {
+			let baseDir = URL(filePath: "/Users/test/")
+
+			@Test("absolute file URL in base directory")
+			func absoluteFileURL() throws {
+				let imageURL = ImageFileURL(
+					fileURL: URL(filePath: "/Users/test/images/photo.jpg"),
+					relativizigWorkingDirectory: baseDir
+				)
+
+				#expect(imageURL.path() == "images/photo.jpg")
+			}
+
+			@Test("relative file URL in base directory")
+			func relativeFileURL() throws {
+				let imageURL = ImageFileURL(
+					fileURL: URL(filePath: "images/photo.jpg", relativeTo: baseDir),
+					relativizigWorkingDirectory: baseDir
+				)
+
+				#expect(imageURL.path() == "images/photo.jpg")
+			}
+
+			@Test("absolute file URL in sibling directory to base")
+			func absoluteFileURLDifferentDirectory() throws {
+				let imageURL = ImageFileURL(
+					fileURL: URL(filePath: "/Users/peter/projects/app/images/photo.jpg"),
+					relativizigWorkingDirectory: baseDir
+				)
+
+				#expect(imageURL.path() == "../peter/projects/app/images/photo.jpg")
+			}
+
+			@Test("relative file URL in sibling directory to base")
+			func relativeFileURLDifferentDirectory() throws {
+				let imageURL = ImageFileURL(
+					fileURL: URL(filePath: "app/images/photo.jpg", relativeTo: URL(filePath: "/Users/peter/projects/")),
+					relativizigWorkingDirectory: baseDir
+				)
+
+				#expect(imageURL.path() == "../peter/projects/app/images/photo.jpg")
+			}
+		}
+	}
+}

--- a/Tests/MarkdownBabelTests/URL+relativePathTests.swift
+++ b/Tests/MarkdownBabelTests/URL+relativePathTests.swift
@@ -1,0 +1,201 @@
+import MarkdownBabel
+import Testing
+
+import struct Foundation.URL
+
+extension URL {
+	/// Programmatic URL intialization from string literals. Raises exception when this fails, as a programmer error.
+	fileprivate init(_ staticString: StaticString) {
+		guard let url = URL(string: "\(staticString)") else {
+			preconditionFailure("URL could not be created from string literal \(staticString)")
+		}
+		self = url
+	}
+}
+
+@Suite("RelativeURLResolving")
+struct RelativeURLResolvingTests {
+	@Suite("Web URLs") struct WebURLTests {
+		@Test func resolvesFolderRelativeToRoot() {
+			#expect(
+				URL("https://example.com/folder/index.html")
+					.relativePath(resolvedAgainst: URL("https://example.com/root.txt")) == "folder/index.html"
+			)
+		}
+
+		@Test("Nothing in common except scheme and domain")
+		func nothingInCommonExceptSchemeAndDomain() {
+			#expect(
+				URL("https://example.com/index.html")
+					.relativePath(resolvedAgainst: URL("https://example.com/path/file.txt")) == "/index.html"
+			)
+		}
+
+		@Test("Detecting common root as shared parent path")
+		func detectingCommonRootAsSharedParentPath() {
+			#expect(
+				URL("https://example.com/index.html")
+					.relativePath(resolvedAgainst: URL("https://example.com/")) == "index.html"
+			)
+		}
+
+		@Test
+		func resolvesIndexInSameDirectory() {
+			#expect(
+				URL("https://example.com/path/index.html")
+					.relativePath(resolvedAgainst: URL("https://example.com/path/other.html")) == "index.html"
+			)
+		}
+
+		@Test("Same path is irrelevant if host doesn't match")
+		func samePathIsIrrelevantIfHostDoesntMatch() {
+			#expect(
+				URL("https://example.com/index.html")
+					.relativePath(resolvedAgainst: URL("https://different.de/path/file.txt"))
+					== "https://example.com/index.html"
+			)
+		}
+
+		@Test("Same path is irrelevant if scheme doesn't match")
+		func samePathIsIrrelevantIfSchemeDoesntMatch() {
+			#expect(
+				URL("ftp://warez.ru/foo/bar/")
+					.relativePath(resolvedAgainst: URL("http://warez.ru/foo/bar/")) == "ftp://warez.ru/foo/bar/"
+			)
+		}
+	}
+
+	@Suite("From root directory") struct RootBase {
+		let base = URL(fileURLWithPath: "/")
+
+		@Test func addingDirectory() {
+			let path = URL(fileURLWithPath: "/dir/")
+			#expect(path.relativePath(resolvedAgainst: base) == "dir")
+		}
+
+		@Test
+		func addingFile() {
+			let path = URL(fileURLWithPath: "/file")
+			#expect(path.relativePath(resolvedAgainst: base) == "file")
+		}
+
+		@Suite("With file in root") struct WithFile {
+			let base = URL(fileURLWithPath: "/irrelevant")
+			@Test
+			func withFileInRoot_AddingDirectory() {
+				let path = URL(fileURLWithPath: "/dir/")
+				#expect(path.relativePath(resolvedAgainst: base) == "dir")
+			}
+
+			@Test
+			func withFileInRoot_AddingFile() {
+				let path = URL(fileURLWithPath: "/file")
+				#expect(path.relativePath(resolvedAgainst: base) == "file")
+			}
+		}
+	}
+
+	@Suite("Shared directory") struct SharedBaseDir {
+		@Test("is fully contained (both are equal)")
+		func samePaths() {
+			let base = URL(fileURLWithPath: "/base/path/")
+			let path = URL(fileURLWithPath: "/base/path/")
+			#expect(path.relativePath(resolvedAgainst: base) == ".")
+		}
+
+		@Test("is followed by another directory")
+		func addingDirectory() {
+			let base = URL(fileURLWithPath: "/tmp/")
+			let path = URL(fileURLWithPath: "/tmp/dir/")
+			#expect(path.relativePath(resolvedAgainst: base) == "dir")
+		}
+
+		@Test("is followed by a file")
+		func addingFile() {
+			let base = URL(fileURLWithPath: "/tmp/")
+			let path = URL(fileURLWithPath: "/tmp/file")
+			#expect(path.relativePath(resolvedAgainst: base) == "file")
+		}
+
+		@Suite("with an additional file in the base URL") struct WithFileInBase {
+			let base = URL(fileURLWithPath: "/tmp/irrelevant")
+			@Test
+			func addingDirectory() {
+				let path = URL(fileURLWithPath: "/tmp/dir/")
+				#expect(path.relativePath(resolvedAgainst: base) == "dir")
+			}
+
+			@Test
+			func addingFile() {
+				let path = URL(fileURLWithPath: "/tmp/file")
+				#expect(path.relativePath(resolvedAgainst: base) == "file")
+			}
+		}
+
+		@Suite("with an additional directory in the base URL") struct WithDirectoryInBase {
+			let base = URL(fileURLWithPath: "/base/directory/")
+
+			@Test
+			func siblingToLastBaseDir() {
+				let path = URL(fileURLWithPath: "/base/sibling/")
+				#expect(path.relativePath(resolvedAgainst: base) == "../sibling")
+			}
+
+			@Test
+			func siblingWithFileToLastBaseDir() {
+				let path = URL(fileURLWithPath: "/base/sibling/file")
+				#expect(path.relativePath(resolvedAgainst: base) == "../sibling/file")
+			}
+
+			@Suite("and a file") struct AndFile {
+				let base = URL(fileURLWithPath: "/base/directory/irrelevant")
+				@Test
+				func siblingToLastBaseDir_WithFileInBaseDir() {
+					let path = URL(fileURLWithPath: "/base/sibling/")
+					#expect(path.relativePath(resolvedAgainst: base) == "../sibling")
+				}
+
+				@Test
+				func siblingWithFileToLastBaseDir_WithFileInBaseDir() {
+					let path = URL(fileURLWithPath: "/base/sibling/file")
+					#expect(path.relativePath(resolvedAgainst: base) == "../sibling/file")
+				}
+			}
+
+			@Test
+			func ancestorOfBase() {
+				let base = URL(fileURLWithPath: "/base/path/to/its/fullest/")
+				let path = URL(fileURLWithPath: "/base/path/")
+				#expect(path.relativePath(resolvedAgainst: base) == "../../..")
+			}
+
+			@Test
+			func siblingToParentOfParentOfBaseDir() {
+				let base = URL(fileURLWithPath: "/base/path/to/its/fullest/")
+				let path = URL(fileURLWithPath: "/base/path/sibling/")
+				#expect(path.relativePath(resolvedAgainst: base) == "../../../sibling")
+			}
+		}
+	}
+
+	@Test
+	func nothingInCommon() {
+		let base = URL(fileURLWithPath: "/base/path/")
+		let path = URL(fileURLWithPath: "/absolute/path")
+		#expect(path.relativePath(resolvedAgainst: base) == "/absolute/path")
+	}
+
+	@Test
+	func relativePath() {
+		let base = URL(fileURLWithPath: "/base/path/")
+		let path = URL(fileURLWithPath: "../sibling/file", relativeTo: base)
+		#expect(path.relativePath(resolvedAgainst: base) == "../sibling/file")
+	}
+
+	@Test
+	func relativePathToBaseParent() {
+		let base = URL(fileURLWithPath: "/base/parent/path/")
+		let path = URL(fileURLWithPath: "../sibling/file", relativeTo: URL(fileURLWithPath: "/base/parent/"))
+		#expect(path.relativePath(resolvedAgainst: base) == "../../sibling/file")
+	}
+}


### PR DESCRIPTION
Requires the `--dir` option to be set to the project root or whichever working directory the user prefers.

Addresses a part of #34