### PR TITLE
Configure automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,4 @@
 changelog:
-  exclude:
-    authors:
-      - dependabot
   categories:
     - title: Features
       labels:
@@ -9,18 +6,6 @@ changelog:
     - title: Bugs fixed
       labels:
         - bug
-    - title: Documentation
-      labels:
-        - documentation
-    - title: CI
-      labels:
-        - ci
     - title: Other Changes
       labels:
         - "*"
-      exclude:
-        labels:
-          - dependabot
-    - title: Dependencies
-      labels:
-        - dependabot

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   categories:
-    - title: Features
+    - title: New features
       labels:
         - enhancement
     - title: Bugs fixed

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bugs fixed
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI
+      labels:
+        - ci
+    - title: Other Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependabot
+    - title: Dependencies
+      labels:
+        - dependabot


### PR DESCRIPTION
I am not sure if we need a separate category for docs and ci. Also, the title could be more engaging.

See also: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
Related to: https://github.com/md-babel/swift-markdown-babel/issues/1