### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "DivineDominion"
+      - "ikelax"
+    labels:
+      - "dependabot"
+  - package-ecosystem: "swift" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "DivineDominion"
+      - "ikelax"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
The PRs generated by Dependabot look like [here](https://github.com/ikelax/swift-dependency-graphs/pull/44) and [here](https://github.com/ikelax/swift-dependency-graphs/pull/45). Note that `Package.resolved` is also updated.

With the schedule interval `monthly` dependabot is run on the [first day of each month](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval).

@DivineDominion You do not have to make any changes in the settings. I tested in the repository [ikelax/template-swift](https://github.com/ikelax/template-swift) if [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) are enabled if `dependabot.yml` is present in `.github`. See for example [PR #7](https://github.com/ikelax/template-swift/pull/7).

See also: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
See also: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
Closes: https://github.com/md-babel/swift-markdown-babel/issues/31